### PR TITLE
feat(monitor status check): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.23
+
+- Add a "Fail early" option to the monitor status check. When enabled (the default, matching the previous behavior), the check fails as soon as a deviating status is observed. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step.
+
 ## v1.8.22
 
 - build(deps): bump alpine from 3.23 to 3.24

--- a/extmonitor/monitor_status_check.go
+++ b/extmonitor/monitor_status_check.go
@@ -38,6 +38,11 @@ type MonitorStatusCheckState struct {
 	StatusCheckMode    string
 	StatusCheckSuccess bool
 	MultiAlertFilter   map[string]string `json:"multiAlertFilter"`
+	FailEarly          bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating status was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewMonitorStatusCheckAction() action_kit_sdk.Action[MonitorStatusCheckState] {
@@ -185,6 +190,16 @@ func (m *MonitorStatusCheckAction) Describe() action_kit_api.ActionDescription {
 				Advanced:    new(true),
 				Order:       new(5),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating status is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(6),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -238,6 +253,12 @@ func (m *MonitorStatusCheckAction) Prepare(_ context.Context, state *MonitorStat
 	if request.Config["statusCheckMode"] != nil {
 		statusCheckMode = fmt.Sprintf("%v", request.Config["statusCheckMode"])
 	}
+
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	failEarly := true
+	if request.Config["failEarly"] != nil {
+		failEarly = extutil.ToBool(request.Config["failEarly"])
+	}
 	if (request.Config["multiAlertFilter"]) != nil {
 		multiAlertFilter, err := extutil.ToKeyValue(request.Config, "multiAlertFilter")
 		if err != nil {
@@ -260,6 +281,7 @@ func (m *MonitorStatusCheckAction) Prepare(_ context.Context, state *MonitorStat
 	state.End = end
 	state.ExpectedStatus = expectedStatus
 	state.StatusCheckMode = statusCheckMode
+	state.FailEarly = failEarly
 
 	return nil, nil
 }
@@ -309,13 +331,27 @@ func monitorStatusCheckStatus(ctx context.Context, state *MonitorStatusCheckStat
 				if len(tags) == 0 {
 					tags = "<none>"
 				}
+				title := fmt.Sprintf("Monitor '%s' (id %d, tags: %s) has status '%s' whereas '%s' is expected.",
+					*monitor.Name,
+					state.MonitorId,
+					tags,
+					strings.Join(monitorStates, ", "),
+					strings.Join(state.ExpectedStatus, ", "))
+				if state.FailEarly {
+					// Fail as soon as a deviating status is observed.
+					checkError = new(action_kit_api.ActionKitError{
+						Title:  title,
+						Status: extutil.Ptr(action_kit_api.Failed),
+					})
+				} else {
+					// Keep collecting events and remember the deviation to report it at the end of the step.
+					state.DeviationSeen = true
+					state.DeviationTitle = title
+				}
+			}
+			if !state.FailEarly && completed && state.DeviationSeen {
 				checkError = new(action_kit_api.ActionKitError{
-					Title: fmt.Sprintf("Monitor '%s' (id %d, tags: %s) has status '%s' whereas '%s' is expected.",
-						*monitor.Name,
-						state.MonitorId,
-						tags,
-						strings.Join(monitorStates, ", "),
-						strings.Join(state.ExpectedStatus, ", ")),
+					Title:  state.DeviationTitle,
 					Status: extutil.Ptr(action_kit_api.Failed),
 				})
 			}

--- a/extmonitor/monitor_status_check_test.go
+++ b/extmonitor/monitor_status_check_test.go
@@ -56,6 +56,7 @@ func TestPrepareExtractsState(t *testing.T) {
 	require.True(t, state.End.After(time.Now()))
 	require.Equal(t, []string{"OK", "No Data"}, state.ExpectedStatus)
 	require.Equal(t, statusCheckModeAtLeastOnce, state.StatusCheckMode)
+	require.True(t, state.FailEarly) // defaults to true when not provided (non-breaking for old experiments)
 }
 
 func TestPrepareExtractsStateWithoutStatusCheck(t *testing.T) {
@@ -93,7 +94,8 @@ func TestPrepareExtractsStateDeprecatedExpextedStatus(t *testing.T) {
 		Config: map[string]any{
 			"duration":        1000 * 60,
 			"expectedStatus":  datadogV1.MONITOROVERALLSTATES_OK,
-			"statusCheckMode": statusCheckModeAtLeastOnce,
+			"statusCheckMode": statusCheckModeAllTheTime,
+			"failEarly":       false,
 		},
 		Target: new(action_kit_api.Target{
 			Attributes: map[string][]string{
@@ -115,7 +117,8 @@ func TestPrepareExtractsStateDeprecatedExpextedStatus(t *testing.T) {
 	require.NotNil(t, state.Start)
 	require.True(t, state.End.After(time.Now()))
 	require.Equal(t, []string{"OK"}, state.ExpectedStatus)
-	require.Equal(t, statusCheckModeAtLeastOnce, state.StatusCheckMode)
+	require.Equal(t, statusCheckModeAllTheTime, state.StatusCheckMode)
+	require.False(t, state.FailEarly) // explicitly set to false in the config
 }
 
 func TestPrepareSupportsMissingExpectedStatus(t *testing.T) {
@@ -306,6 +309,7 @@ func TestAllTheTimeExpectationMismatch(t *testing.T) {
 	state.End = time.Now().Add(time.Minute * 1) // time not yet up - early exit
 	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
 	state.StatusCheckMode = statusCheckModeAllTheTime
+	state.FailEarly = true
 
 	// When
 	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
@@ -354,6 +358,7 @@ func TestAllTheTimeExpectationMismatchWithMultiAlertFilter(t *testing.T) {
 	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
 	state.StatusCheckMode = statusCheckModeAllTheTime
 	state.MultiAlertFilter = map[string]string{"namespace": "default"}
+	state.FailEarly = true
 
 	// When
 	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
@@ -370,6 +375,90 @@ func TestAllTheTimeExpectationMismatchWithMultiAlertFilter(t *testing.T) {
 	require.Equal(t, "gateway pods ready with filter namespace:default", metric.Metric["datadog.monitor.name"])
 	require.NotNil(t, metric.Timestamp)
 	require.Equal(t, float64(0), metric.Value)
+}
+
+func TestAllTheTimeFailAtEnd(t *testing.T) {
+	// ----------------------------------------
+	// First Call: Status deviates but time is not up - no error yet, deviation is remembered
+	// ----------------------------------------
+	// Given
+	mockedApi := new(datadogGetMonitorClientMock)
+	mockedApi.On("GetMonitor", mock.Anything, mock.Anything, mock.Anything).Return(datadogV1.Monitor{
+		Name:         new("gateway pods ready"),
+		Id:           new(int64(1234)),
+		OverallState: extutil.Ptr(datadogV1.MONITOROVERALLSTATES_WARN),
+	}, new(http.Response{
+		StatusCode: 200,
+	}), nil).Once()
+
+	action := MonitorStatusCheckAction{}
+	state := action.NewEmptyState()
+	state.MonitorId = 1234
+	state.End = time.Now().Add(time.Minute * 1) // time not yet up
+	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
+	state.StatusCheckMode = statusCheckModeAllTheTime
+	state.FailEarly = false
+
+	// When
+	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
+
+	// Then
+	require.Nil(t, err)
+	require.False(t, result.Completed)
+	require.Nil(t, result.Error) // does not fail early
+	require.True(t, state.DeviationSeen)
+
+	// ----------------------------------------
+	// Second Call: Status recovered but a deviation was seen earlier and time is up - fails at the end
+	// ----------------------------------------
+	// Given
+	mockedApi.On("GetMonitor", mock.Anything, mock.Anything, mock.Anything).Return(datadogV1.Monitor{
+		Name:         new("gateway pods ready"),
+		Id:           new(int64(1234)),
+		OverallState: extutil.Ptr(datadogV1.MONITOROVERALLSTATES_OK),
+	}, new(http.Response{
+		StatusCode: 200,
+	}), nil).Once()
+	state.End = time.Now().Add(time.Minute * -1) // time is up
+
+	// When
+	result, err = monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
+
+	// Then
+	require.Nil(t, err)
+	require.True(t, result.Completed)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "Monitor 'gateway pods ready' (id 1234, tags: <none>) has status 'Warn' whereas 'OK' is expected.", result.Error.Title)
+	require.Contains(t, *result.Error.Status, action_kit_api.Failed)
+}
+
+func TestAllTheTimeFailAtEndSucceedsWhenNeverDeviated(t *testing.T) {
+	// Given - status is always as expected, time is up
+	mockedApi := new(datadogGetMonitorClientMock)
+	mockedApi.On("GetMonitor", mock.Anything, mock.Anything, mock.Anything).Return(datadogV1.Monitor{
+		Name:         new("gateway pods ready"),
+		Id:           new(int64(1234)),
+		OverallState: extutil.Ptr(datadogV1.MONITOROVERALLSTATES_OK),
+	}, new(http.Response{
+		StatusCode: 200,
+	}), nil)
+
+	action := MonitorStatusCheckAction{}
+	state := action.NewEmptyState()
+	state.MonitorId = 1234
+	state.End = time.Now().Add(time.Minute * -1) // time is up
+	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
+	state.StatusCheckMode = statusCheckModeAllTheTime
+	state.FailEarly = false
+
+	// When
+	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
+
+	// Then
+	require.Nil(t, err)
+	require.True(t, result.Completed)
+	require.Nil(t, result.Error)
+	require.False(t, state.DeviationSeen)
 }
 
 func TestAtLeastOnceSuccess(t *testing.T) {


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. Depending on the check mode and configuration, a check may fail early (on the first deviating event) or only at the end of the step, with no way to control which.

This is the reference implementation for the cross-extension rework, starting with the Datadog Monitor Status check.

## Change

Adds a **`failEarly` boolean** parameter to the Monitor Status check:

- **Enabled (default)** — the check fails as soon as a deviating status is observed (today's `All the time` behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare` (when the key is absent), so **existing experiments are non-breaking**.
- Fail-at-end is implemented by remembering the deviation in state (`DeviationSeen`/`DeviationTitle`) and only emitting the error once the step completes.
- Only affects `All the time` mode. `At least once` can only be evaluated at the end of the step, so the option is a no-op there (documented in the parameter description).

The parameter description is what the Hub renders, satisfying the "documented in the Hub" acceptance criterion.

## Tests

- Updated existing `All the time` mismatch test to set `FailEarly = true` explicitly (struct zero value is now `false`).
- Added `TestAllTheTimeFailAtEnd` and `TestAllTheTimeFailAtEndSucceedsWhenNeverDeviated`.
- 20/20 tests pass, `go vet` clean.