### PR TITLE
fix(monitor status check): fail when monitor status is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.24
+
+- Fix: the monitor status check no longer completes successfully when the monitor status cannot be determined (an unknown/no-data state, or a multi alert filter that matches no group). When an expected status is configured, an undeterminable status is now treated as a non-match, so "At least once" fails at the end and "All the time" reports a deviation.
+
 ## v1.8.23
 
 - Add a "Fail early" option to the monitor status check. When enabled (the default, matching the previous behavior), the check fails as soon as a deviating status is observed. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step.

--- a/extmonitor/monitor_status_check.go
+++ b/extmonitor/monitor_status_check.go
@@ -323,10 +323,18 @@ func monitorStatusCheckStatus(ctx context.Context, state *MonitorStatusCheckStat
 	completed := now.After(state.End)
 	var checkError *action_kit_api.ActionKitError
 	monitorStates := getMonitorStates(&monitor, state)
-	if len(state.ExpectedStatus) > 0 && len(monitorStates) > 0 {
+	if len(state.ExpectedStatus) > 0 {
 		log.Debug().Str("monitor", *monitor.Name).Strs("status", monitorStates).Strs("expected", state.ExpectedStatus).Msg("Monitor status")
+		// An empty monitorStates means the status could not be determined (e.g. the monitor reports
+		// an unknown/no-data state, or a multi alert filter matched no group). Treat that as a
+		// non-match so the check does not silently pass when the expected status was never observed.
+		statusMatches := len(monitorStates) > 0 && containsOnly(monitorStates, state.ExpectedStatus)
+		observedStatus := "Unknown"
+		if len(monitorStates) > 0 {
+			observedStatus = strings.Join(monitorStates, ", ")
+		}
 		if state.StatusCheckMode == statusCheckModeAllTheTime {
-			if !containsOnly(monitorStates, state.ExpectedStatus) {
+			if !statusMatches {
 				tags := strings.Join(monitor.Tags, ", ")
 				if len(tags) == 0 {
 					tags = "<none>"
@@ -335,7 +343,7 @@ func monitorStatusCheckStatus(ctx context.Context, state *MonitorStatusCheckStat
 					*monitor.Name,
 					state.MonitorId,
 					tags,
-					strings.Join(monitorStates, ", "),
+					observedStatus,
 					strings.Join(state.ExpectedStatus, ", "))
 				if state.FailEarly {
 					// Fail as soon as a deviating status is observed.
@@ -356,7 +364,7 @@ func monitorStatusCheckStatus(ctx context.Context, state *MonitorStatusCheckStat
 				})
 			}
 		} else if state.StatusCheckMode == statusCheckModeAtLeastOnce {
-			if containsOnly(monitorStates, state.ExpectedStatus) {
+			if statusMatches {
 				state.StatusCheckSuccess = true
 			}
 			if completed && !state.StatusCheckSuccess {

--- a/extmonitor/monitor_status_check_test.go
+++ b/extmonitor/monitor_status_check_test.go
@@ -461,6 +461,63 @@ func TestAllTheTimeFailAtEndSucceedsWhenNeverDeviated(t *testing.T) {
 	require.False(t, state.DeviationSeen)
 }
 
+func TestAtLeastOnceFailsOnUnknownStatus(t *testing.T) {
+	// Given - the monitor never reports a determinable status (overall state is unknown -> no states)
+	mockedApi := new(datadogGetMonitorClientMock)
+	mockedApi.On("GetMonitor", mock.Anything, mock.Anything, mock.Anything).Return(datadogV1.Monitor{
+		Name: new("gateway pods ready"),
+		Id:   new(int64(1234)),
+	}, new(http.Response{
+		StatusCode: 200,
+	}), nil)
+
+	action := MonitorStatusCheckAction{}
+	state := action.NewEmptyState()
+	state.MonitorId = 1234
+	state.End = time.Now().Add(time.Minute * -1) // time is up
+	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
+	state.StatusCheckMode = statusCheckModeAtLeastOnce
+
+	// When
+	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
+
+	// Then - an unknown status must not count as success, so the check fails at the end
+	require.Nil(t, err)
+	require.True(t, result.Completed)
+	require.False(t, state.StatusCheckSuccess)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "Monitor 'gateway pods ready' (id 1234, tags: <none>) didn't have status '[OK]' at least once.", result.Error.Title)
+	require.Contains(t, *result.Error.Status, action_kit_api.Failed)
+}
+
+func TestAllTheTimeFailsOnUnknownStatus(t *testing.T) {
+	// Given - the monitor never reports a determinable status (overall state is unknown -> no states)
+	mockedApi := new(datadogGetMonitorClientMock)
+	mockedApi.On("GetMonitor", mock.Anything, mock.Anything, mock.Anything).Return(datadogV1.Monitor{
+		Name: new("gateway pods ready"),
+		Id:   new(int64(1234)),
+	}, new(http.Response{
+		StatusCode: 200,
+	}), nil)
+
+	action := MonitorStatusCheckAction{}
+	state := action.NewEmptyState()
+	state.MonitorId = 1234
+	state.End = time.Now().Add(time.Minute * 1) // time not yet up
+	state.ExpectedStatus = []string{string(datadogV1.MONITOROVERALLSTATES_OK)}
+	state.StatusCheckMode = statusCheckModeAllTheTime
+	state.FailEarly = true
+
+	// When
+	result, err := monitorStatusCheckStatus(context.Background(), &state, mockedApi, "http://example.com")
+
+	// Then - an unknown status deviates from the expected status
+	require.Nil(t, err)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "Monitor 'gateway pods ready' (id 1234, tags: <none>) has status 'Unknown' whereas 'OK' is expected.", result.Error.Title)
+	require.Contains(t, *result.Error.Status, action_kit_api.Failed)
+}
+
 func TestAtLeastOnceSuccess(t *testing.T) {
 	// ----------------------------------------
 	// First Call: Status is not ok - StatusCheckSuccess in State is still false - no exit (End not yet reached)


### PR DESCRIPTION
## Problem

A monitor status check could complete **successfully even when the expected status was never observed**, if the monitor status could not be determined — e.g. an unknown/no-data overall state, or a multi alert filter that matched no group.

Repro (reported): `At least once`, expected status `OK`, *Fail early* off, against a multi-alert monitor whose filter matched no group → the run completed green while the status was `Unknown` the whole time.

## Cause

`monitorStatusCheckStatus` guarded the entire evaluation with `len(monitorStates) > 0`. When no state could be determined (`monitorStates` empty), the block was skipped — `StatusCheckSuccess` was never set and no error was raised — so the step completed green. (This predates the Fail early change; the original code skipped the same way via `monitor.OverallState != nil`.)

Note `containsOnly([], expected)` returns `true` vacuously, so the empty case has to be handled explicitly rather than just dropping the guard.

## Fix

Evaluate whenever an expected status is configured, and treat "no observable matching state" as an explicit **non-match**:

- `statusMatches := len(monitorStates) > 0 && containsOnly(monitorStates, expected)`
- **At least once** — an undeterminable status no longer marks success, so the check fails at the end (`didn't have status … at least once`).
- **All the time** — an undeterminable status is reported as a deviation (`has status 'Unknown' whereas '…' is expected`).

## Behavior change

An `Unknown`/no-data monitor (or a multi alert filter matching no group) will now **fail** a check that has an expected status, instead of silently passing.

## Tests

- Added `TestAtLeastOnceFailsOnUnknownStatus` and `TestAllTheTimeFailsOnUnknownStatus`.
- 30/30 tests pass, `go vet` clean.