### PR TITLE
fix(monitor status check): use past tense for fail-at-end message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.25
+
+- Use past tense ("had status") for the monitor status check failure message when "Fail early" is disabled, since the monitor status may have recovered by the time the failure is reported at the end of the step. The fail-early message keeps the present tense ("has status").
+
 ## v1.8.24
 
 - Fix: the monitor status check no longer completes successfully when the monitor status cannot be determined (an unknown/no-data state, or a multi alert filter that matches no group). When an expected status is configured, an undeterminable status is now treated as a non-match, so "At least once" fails at the end and "All the time" reports a deviation.

--- a/extmonitor/monitor_status_check.go
+++ b/extmonitor/monitor_status_check.go
@@ -339,22 +339,20 @@ func monitorStatusCheckStatus(ctx context.Context, state *MonitorStatusCheckStat
 				if len(tags) == 0 {
 					tags = "<none>"
 				}
-				title := fmt.Sprintf("Monitor '%s' (id %d, tags: %s) has status '%s' whereas '%s' is expected.",
-					*monitor.Name,
-					state.MonitorId,
-					tags,
-					observedStatus,
-					strings.Join(state.ExpectedStatus, ", "))
+				expectedStatus := strings.Join(state.ExpectedStatus, ", ")
 				if state.FailEarly {
-					// Fail as soon as a deviating status is observed.
+					// Fail as soon as a deviating status is observed (present tense - it is deviating now).
 					checkError = new(action_kit_api.ActionKitError{
-						Title:  title,
+						Title: fmt.Sprintf("Monitor '%s' (id %d, tags: %s) has status '%s' whereas '%s' is expected.",
+							*monitor.Name, state.MonitorId, tags, observedStatus, expectedStatus),
 						Status: extutil.Ptr(action_kit_api.Failed),
 					})
 				} else {
-					// Keep collecting events and remember the deviation to report it at the end of the step.
+					// Keep collecting events and remember the deviation to report it at the end of the
+					// step (past tense - the status may have recovered by the time this is reported).
 					state.DeviationSeen = true
-					state.DeviationTitle = title
+					state.DeviationTitle = fmt.Sprintf("Monitor '%s' (id %d, tags: %s) had status '%s' whereas '%s' is expected.",
+						*monitor.Name, state.MonitorId, tags, observedStatus, expectedStatus)
 				}
 			}
 			if !state.FailEarly && completed && state.DeviationSeen {

--- a/extmonitor/monitor_status_check_test.go
+++ b/extmonitor/monitor_status_check_test.go
@@ -428,7 +428,7 @@ func TestAllTheTimeFailAtEnd(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, result.Completed)
 	require.NotNil(t, result.Error)
-	require.Equal(t, "Monitor 'gateway pods ready' (id 1234, tags: <none>) has status 'Warn' whereas 'OK' is expected.", result.Error.Title)
+	require.Equal(t, "Monitor 'gateway pods ready' (id 1234, tags: <none>) had status 'Warn' whereas 'OK' is expected.", result.Error.Title)
 	require.Contains(t, *result.Error.Status, action_kit_api.Failed)
 }
 


### PR DESCRIPTION
## Context

Follow-up to the "Fail early" option (#211). A PR reviewer on the same change in `extension-grafana` flagged that the **fail-at-end** failure message is frozen in **present tense** ("has status 'X'"). If the monitor recovers before the step ends, the end-of-step error still reads "has status 'X'" even though the current status is fine — historically true, but the wording can mislead operators.

## Change

- **Fail early** (default): keeps present tense — `has status '…'` (it is deviating at that moment).
- **Fail at end** (Fail early disabled): uses past tense — `had status '…'` (the status may have recovered by the time it is reported).

No behavior change; message wording only.

## Tests

- Updated `TestAllTheTimeFailAtEnd` to assert the past-tense message; fail-early/unknown-status tests keep the present tense.
- All `extmonitor` tests pass, `go vet` clean.