### PR TITLE
fix: emit the monitor status metric immediately on Start

### DIFF
--- a/extmonitor/monitor_status_check.go
+++ b/extmonitor/monitor_status_check.go
@@ -286,8 +286,17 @@ func (m *MonitorStatusCheckAction) Prepare(_ context.Context, state *MonitorStat
 	return nil, nil
 }
 
-func (m *MonitorStatusCheckAction) Start(_ context.Context, _ *MonitorStatusCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *MonitorStatusCheckAction) Start(ctx context.Context, state *MonitorStatusCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := monitorStatusCheckStatus(ctx, state, &config.Config, config.Config.SiteUrl)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *MonitorStatusCheckAction) Status(ctx context.Context, state *MonitorStatusCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `Start()` was a no-op, so the first `datadog_monitor_status` metric only appeared after the first `Status()` poll (one `CallInterval`, i.e. 5s, after the check started).
- `Start()` now reuses the same status-check logic as `Status()`, so the first metric is emitted immediately when the check starts — matching the pattern already used by e.g. New Relic's incident check.

## Test plan
- [x] `go build ./...`
- [x] `go test ./extmonitor/...`